### PR TITLE
Added MSYS2 build

### DIFF
--- a/Makefile.msys2
+++ b/Makefile.msys2
@@ -1,0 +1,91 @@
+# Makefile for umac
+#
+# Builds Musashi as submodule, unix_main as SDL2 test application.
+#
+# Copyright 2024 Matt Evans
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+DEBUG ?= 0
+MEMSIZE ?= 128
+
+SOURCES = $(wildcard src/*.c)
+
+MUSASHI = external/Musashi/
+MUSASHI_SRC = $(MUSASHI)/m68kcpu.c $(MUSASHI)/m68kdasm.c $(MUSASHI)/m68kops.c $(MUSASHI)/softfloat/softfloat.c
+MY_OBJS = $(patsubst %.c, %.o, $(SOURCES))
+MUSASHI_OBJS = $(patsubst %.c, %.o, $(MUSASHI_SRC))
+OBJS = $(MY_OBJS) $(MUSASHI_OBJS)
+
+SDL_CFLAGS = $(shell sdl2-config --cflags)
+SDL_LIBS = $(shell sdl2-config --libs)
+
+LINKFLAGS =
+LIBS = $(SDL_LIBS) -lm -lmman
+
+INCLUDEFLAGS = -Iinclude/ -I$(MUSASHI) $(SDL_CFLAGS) -DMUSASHI_CNF=\"../include/m68kconf.h\"
+INCLUDEFLAGS += -DENABLE_DASM=1
+INCLUDEFLAGS += -DUMAC_MEMSIZE=$(MEMSIZE)
+CFLAGS = $(INCLUDEFLAGS) -Wall -Wextra -pedantic -DSIM
+
+ifeq ($(DEBUG),1)
+	CFLAGS += -Og -g -ggdb -DDEBUG
+endif
+
+all:	main
+
+$(MUSASHI_SRC): $(MUSASHI)/m68kops.h
+
+$(MUSASHI)/m68kops.c $(MUSASHI)/m68kops.h:
+	make -C $(MUSASHI) m68kops.c m68kops.h && ./tools/decorate_ops.py $(MUSASHI)/m68kops.c tools/fn_hot200.txt
+
+prepare:	$(MUSASHI)/m68kops.c $(MUSASHI)/m68kops.h
+
+%.o:	%.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+main:	$(OBJS)
+	@echo Linking $(OBJS)
+	$(CC) $(LINKFLAGS) $^ $(LIBS) -o $@
+
+clean:
+	make -C $(MUSASHI) clean
+	rm -f $(MY_OBJS) main
+
+################################################################################
+# Mac driver sources (no need to generally rebuild
+# Needs a m68k-linux-gnu binutils, but not GCC.
+
+M68K_CROSS ?= m68k-linux-gnu-
+M68K_AS = $(M68K_CROSS)as
+M68K_LD = $(M68K_CROSS)ld
+M68K_OBJCOPY = $(M68K_CROSS)objcopy
+
+include/sonydrv.h:	sonydrv.bin
+	xxd -i < $< > $@
+
+.PHONY: sonydrv.bin
+sonydrv.bin:	macsrc/sonydrv.S
+	@# Yum hacky
+	cpp $< | $(M68K_AS) -o sonydrv.o
+	$(M68K_LD) sonydrv.o -o sonydrv.elf -Ttext=0
+	$(M68K_OBJCOPY) sonydrv.elf -O binary --keep-section=.text $@

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ A simple SDL2-based frontend builds on Linux.
 To build on Linux, you'll need `SDL2` installed (packaged as
 `libsdl2-dev` on Ubuntu).
 
+To build in MSYS2 on Windows (mingw32, mingw64 environments have been tested), you also need [mman-win32](https://github.com/Arakula/mman-win32/) installed for the build environment of your choice.
+
 Musashi is included as a submodule, currently a custom branch with
 some optimisations for static/tiny/fast builds.  `git submodule update --init`
 
@@ -110,6 +112,13 @@ chars 'LK'.  Some emulators append a header (which can be `dd`'d off).
 
 # Build
 
+To build in MSYS2 on Windows, use
+```
+make -f Makefile.msys2
+```
+(the only difference to the normal Makefile is the addition of ä`-lmman` to the libraries list).
+
+On Linux or macOS, use
 ```
 make
 ```

--- a/src/unix_main.c
+++ b/src/unix_main.c
@@ -44,6 +44,11 @@
 
 #include "keymap_sdl.h"
 
+#ifndef O_BINARY
+/* O_BINARY not defined? Not necessary, either. */
+#define O_BINARY 0
+#endif
+
 static void     print_help(char *n)
 {
         printf("Syntax: %s <options>\n"
@@ -137,7 +142,7 @@ int     main(int argc, char *argv[])
         // Load memories/discs
 
         printf("Opening ROM '%s'\n", rom_filename);
-        ofd = open(rom_filename, O_RDONLY);
+        ofd = open(rom_filename, O_RDONLY | O_BINARY);
         if (ofd < 0) {
                 perror("ROM");
                 return 1;
@@ -156,7 +161,7 @@ int     main(int argc, char *argv[])
                 return 1;
         }
         if (rom_dump_filename) {
-                int rfd = open(rom_dump_filename, O_CREAT | O_TRUNC | O_RDWR, 0655);
+                int rfd = open(rom_dump_filename, O_CREAT | O_TRUNC | O_RDWR | O_BINARY, 0655);
                 if (rfd < 0) {
                         perror("ROM dump");
                         return 1;
@@ -176,7 +181,7 @@ int     main(int argc, char *argv[])
         }
 
         /* Set up RAM, shared file map: */
-        ofd = open(ram_filename, O_CREAT | O_TRUNC | O_RDWR, 0644);
+        ofd = open(ram_filename, O_CREAT | O_TRUNC | O_RDWR | O_BINARY, 0644);
         if (ofd < 0) {
                 perror("RAM");
                 return 1;
@@ -197,7 +202,7 @@ int     main(int argc, char *argv[])
         if (disc_filename) {
                 printf("Opening disc '%s'\n", disc_filename);
                 // FIXME: >1 disc
-                ofd = open(disc_filename, opt_write ? O_RDWR : O_RDONLY);
+                ofd = open(disc_filename, (opt_write ? O_RDWR : O_RDONLY) | O_BINARY);
                 if (ofd < 0) {
                         perror("Disc");
                         return 1;
@@ -219,7 +224,7 @@ int     main(int argc, char *argv[])
                         printf("Can't mmap disc!\n");
                         return 1;
                 }
-                printf("Disc mapped at %p, size %ld\n", (void *)disc_base, disc_size);
+                printf("Disc mapped at %p, size %ld\n", (void *)disc_base, (long)disc_size);
 
                 discs[0].base = disc_base;
                 discs[0].read_only = 0;         /* See above */


### PR DESCRIPTION
Minimal adaptation of the original to make it compilable on Windows with MSYS2.
Tested in MSYS2's mingw32 and mingw64 environments.

To use it, apart from gcc, the following additional installation is needed:
```
pacman -S --needed --noconfirm ${MINGW_PACKAGE_PREFIX}-SDL2
```
Plus, [mman-win32](https://github.com/Arakula/mman-win32/) needs to be compiled and installed, since MinGW doesn't contain the `mmap` functionality. Makefile.msys2 has been added which adds the mman library, since that's not part of the standard libraries in mingw (other than that, no difference).