### PR TITLE
Minimal audio implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,10 @@ DISP_WIDTH ?= 512
 DISP_HEIGHT ?= 342
 CFLAGS_CFG = -DDISP_WIDTH=$(DISP_WIDTH) -DDISP_HEIGHT=$(DISP_HEIGHT) -DENABLE_AUDIO=$(ENABLE_AUDIO)
 
-all:	main
+all:	main patcher
+
+patcher: src/rom.c
+	$(CC) $(CFLAGS) -DUMAC_STANDALONE_PATCHER -o $@ $<
 
 $(MUSASHI_SRC): $(MUSASHI)/m68kops.h
 
@@ -75,7 +78,7 @@ main:	$(OBJS)
 
 clean:
 	make -C $(MUSASHI) clean
-	rm -f $(MY_OBJS) main
+	rm -f $(MY_OBJS) main patcher
 
 ################################################################################
 # Mac driver sources (no need to generally rebuild

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@
 
 DEBUG ?= 0
 MEMSIZE ?= 128
+ENABLE_AUDIO ?= 1
 
 SOURCES = $(wildcard src/*.c)
 
@@ -54,7 +55,7 @@ endif
 # Basic support for changing screen res (with the MacPlusV3 ROM)
 DISP_WIDTH ?= 512
 DISP_HEIGHT ?= 342
-CFLAGS_CFG = -DDISP_WIDTH=$(DISP_WIDTH) -DDISP_HEIGHT=$(DISP_HEIGHT)
+CFLAGS_CFG = -DDISP_WIDTH=$(DISP_WIDTH) -DDISP_HEIGHT=$(DISP_HEIGHT) -DENABLE_AUDIO=$(ENABLE_AUDIO)
 
 all:	main
 

--- a/include/machw.h
+++ b/include/machw.h
@@ -81,6 +81,8 @@ extern int overlay;
  * But, that should never happen post-boot.
  */
 #define CLAMP_RAM_ADDR(x) ((x) >= RAM_SIZE ? (x) % RAM_SIZE : (x))
+/* Is the address (previously clamped with CLAMP_RAM_ADDR) the audio trap address? (last byte of audio data) */
+#define IS_RAM_AUDIO_TRAP(x) (x == umac_get_audio_offset() + 2 * 369)
 
 #define IS_VIA(x)       ((ADR24(x) & 0xe80000) == 0xe80000)
 #define IS_IWM(x)       ((ADR24(x) >= 0xdfe1ff) && (ADR24(x) < (0xdfe1ff + 0x2000)))

--- a/include/umac.h
+++ b/include/umac.h
@@ -53,4 +53,9 @@ static inline unsigned int      umac_get_fb_offset(void)
         return RAM_SIZE - ((DISP_WIDTH * DISP_HEIGHT / 8) + 0x380);
 }
 
+#define umac_get_audio_offset() (RAM_SIZE - 768)
+#define umac_get_audio_offset_end() (RAM_SIZE - 768 + 2 * 370)
+
+extern int umac_volume;
+
 #endif

--- a/include/umac.h
+++ b/include/umac.h
@@ -53,9 +53,12 @@ static inline unsigned int      umac_get_fb_offset(void)
         return RAM_SIZE - ((DISP_WIDTH * DISP_HEIGHT / 8) + 0x380);
 }
 
+#if ENABLE_AUDIO
 #define umac_get_audio_offset() (RAM_SIZE - 768)
 #define umac_get_audio_offset_end() (RAM_SIZE - 768 + 2 * 370)
 
-extern int umac_volume;
+void umac_audio_trap();
+void umac_audio_cfg(int volume, int sndres);
+#endif
 
 #endif

--- a/include/umac.h
+++ b/include/umac.h
@@ -56,6 +56,9 @@ static inline unsigned int      umac_get_fb_offset(void)
 #if ENABLE_AUDIO
 #define umac_get_audio_offset() (RAM_SIZE - 768)
 #define umac_get_audio_offset_end() (RAM_SIZE - 768 + 2 * 370)
+extern unsigned first_audio_sample;
+#define umac_get_first_audio_sample() (first_audio_sample)
+#define umac_reset_first_audio_sample() (first_audio_sample = 0, (void)0)
 
 void umac_audio_trap();
 void umac_audio_cfg(int volume, int sndres);

--- a/include/via.h
+++ b/include/via.h
@@ -40,7 +40,8 @@ struct via_cb {
 void    via_init(struct via_cb *cb);
 void    via_write(unsigned int address, uint8_t data);
 uint8_t via_read(unsigned int address);
-void    via_tick(uint64_t time);
+void    via_tick(int cycles);
+int     via_limit_cycles(int cycles);
 /* Trigger an event on CA1 or CA2: */
 void    via_caX_event(int ca);
 void    via_sr_rx(uint8_t val);

--- a/src/main.c
+++ b/src/main.c
@@ -668,8 +668,7 @@ int     umac_loop(void)
         int cycles = UMAC_EXECLOOP_QUANTUM * 8;
         cycles = via_limit_cycles(cycles);
         int used_cycles = m68k_execute(cycles);
-printf("Asked to execute %d cycles, actual %d cycles\n",
-cycles, used_cycles);
+        MDBG("Asked to execute %d cycles, actual %d cycles\n", cycles, used_cycles);
         global_cycles += used_cycles;
         global_time_us = global_cycles / 8;
 

--- a/src/main.c
+++ b/src/main.c
@@ -40,6 +40,7 @@
 #include <errno.h>
 #include <setjmp.h>
 
+#include "umac.h"
 #include "machw.h"
 #include "m68k.h"
 #include "via.h"
@@ -70,6 +71,7 @@ static unsigned int g_int_controller_highest_int = 0;  /* Highest pending interr
 uint8_t *_ram_base;
 uint8_t *_rom_base;
 
+int umac_volume = 0;
 int overlay = 1;
 static uint64_t global_time_us = 0;
 static int sim_done = 0;
@@ -154,6 +156,7 @@ static void     via_ra_changed(uint8_t val)
                 MDBG("OVERLAY CHANGING\n");
                 update_overlay_layout();
         }
+        umac_volume = val & 7;
 
         oldval = val;
 }

--- a/src/rom.c
+++ b/src/rom.c
@@ -116,6 +116,9 @@ static void     rom_patch_plusv3(uint8_t *rom_base)
          * allowing the ROM checksum to fail (it returns failure, then
          * we carry on).  This avoids wild RAM addrs being accessed.
          */
+
+        /* Fix up the sound buffer as used by BootBeep */
+        ROM_WR32(0x292, RAM_SIZE - 768);
 #endif
 
 #if DISP_WIDTH != 512 || DISP_HEIGHT != 342

--- a/src/unix_main.c
+++ b/src/unix_main.c
@@ -403,6 +403,18 @@ int     main(int argc, char *argv[])
                         umac_vsync_event();
 
                         copy_fb(framebuffer, ram_get_base() + umac_get_fb_offset());
+
+        uint16_t *audioptr = (uint16_t*)((uint8_t*)ram_base + umac_get_audio_offset());
+        for(int i=0; i<DISP_HEIGHT; i++) {
+            int d = *audioptr++ & 0xff;
+            for(int j=0; j<8; j++) {
+                if (d & (1 << j)) {
+                    uint32_t fbdata = framebuffer[j + i * DISP_WIDTH];
+                    fbdata = (fbdata & ~0xff) | ((d & (1 << j)) ? 0xff : 0);
+                    framebuffer[j + i * DISP_WIDTH] = fbdata;
+                }
+            }
+        }
                         SDL_UpdateTexture(texture, NULL, framebuffer,
                                           DISP_WIDTH * sizeof (Uint32));
                         /* Scales texture up to window size */

--- a/src/via.c
+++ b/src/via.c
@@ -339,7 +339,7 @@ void    via_tick(int cycles)
             if (i <= 0) {
                 i = 0;
                 VDBG("[VIA T2 reached zero, IRQ pending]\n");
-                irq_active |= VIA_IRQ_T2;
+                // irq_active |= VIA_IRQ_T2;
                 via_assess_irq();
             }
             via_t2c = i;

--- a/src/via.c
+++ b/src/via.c
@@ -243,7 +243,6 @@ void    via_write(unsigned int address, uint8_t data)
                 }
                 // writing T2CH clears associated IRQ flag
                 irq_active &= ~VIA_IRQ_T2;
-                via_assess_irq();
                 break;
         case VIA_T2CL:
                 VDBG("VIA T2CL %02x [ACR=%02x]\n", data, via_regs[VIA_ACR]);
@@ -313,7 +312,6 @@ uint8_t via_read(unsigned int address)
                 data = via_t2c & 0xff;
                 // reading T2LL clears associated IRQ flag
                 irq_active &= ~VIA_IRQ_T2;
-                via_assess_irq();
                 break;
         default:
                 VDBG("[VIA: unhandled RD of %s (reg 0x%x)]\n", rname, r);


### PR DESCRIPTION
This is good enough to play the system beep (which is at a multiple of the refresh rate, so every buffer contains an integer number of cycles of the tone)

However, because the audio buffer filling is not synchronized with vertical retrace, it's probably not good enough for playing other kinds of audio.